### PR TITLE
Add https to container connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 MOUNTFOLDER=/mnt/hms-docker_data
 DATAFOLDER=/hms-docker_config
 LOCALDOMAIN=local
+LETSENCRYPT_EMAIL=test@test.com
 RESTARTPOLICY=always
 VPNUSER=<your VPN email>
 VPNPASS=<your VPN password>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ On container boot, the reverse proxy powered by ```jwilder/nginx-proxy``` obtain
 
 **It is _highly_ recommended that you use a static IP for the docker host machine.**
 
-You will need to update your DNS to point all A records for these hostnames towards the docker host IP, the reverse proxy will handle the rest by serving the data on port 80.
+You will need to update your DNS to point all A records for these hostnames towards the docker host IP, the reverse proxy will handle the rest by serving the data on port 443.
 
 **If you _do not want_ to update your DNS**, you can still access the services by going to ```<docker host IP>:<port of service>```, or you can create a single "catch all" A record (e.g. ```hms-docker.local```) pointing towards the docker host IP and then specifying the port afterwards (```hms-docker.local:<port>```), the ports for services are listed below:
 
@@ -57,6 +57,8 @@ Service ports:
 - Ombi: 3579
 - Jackett: 9117
 - Transmission: 9091
+
+**Note:** Since letsencrypt is used by default and it requires letsencrypt to validate the domain, it's required to add the environment variable [`LETSENCRYPT_TEST` set to `true`](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/blob/master/docs/Let's-Encrypt-and-ACME.md#test-certificates) to every container that uses the `LETSENCRYPT_HOST` and `LETSENCRYPT_EMAIL`. This configuration should be added to `docker-compose.override.yml` to allow every host to have their own configuration (with valid SSL certificate or not).
 
 Although it is device-specific, you can update your ```/etc/hosts``` file (or ```C:\Windows\System32\drivers\etc\hosts``` on Windows) with the format
 ```
@@ -82,7 +84,7 @@ Or you can create the single "catch all" record in this ```hosts``` file and jus
 The Transmission container from ```haugene/docker-transmission-openvpn``` also includes an OpenVPN client as well as a HTTP proxy (running on port 8888 of the transmission container) for other containers to route traffic through the VPN. You can find all supported VPN providers and configurations at https://github.com/haugene/docker-transmission-openvpn.
 
 ## How everything connects
-- After port 80 is forwarded, update the DNS with your registrar to add a ```ombi.<TLD domain>``` that resolves to your IP so you can access ombi from anywhere thanks to the reverse proxy.
+- After port 80 and 443 are forwarded, update the DNS with your registrar to add a ```ombi.<TLD domain>``` that resolves to your IP so you can access ombi from anywhere thanks to the reverse proxy.
 - Ombi sends any requests to Sonarr and Radarr, which contact Jackett to query a large number of trackers.
 - Once a match is found, Sonarr and Radarr will determine if it should download it based on the quality profiles you specify and then send it off to Transmission to download.
 - After it's done downloading/seeding, Sonarr or Radarr will link it to the Plex media folder and notify Ombi that it's ready on Plex.
@@ -91,6 +93,8 @@ The Transmission container from ```haugene/docker-transmission-openvpn``` also i
 ## Built With
 - [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy)
   - Provides the dynamic reverse proxy
+- [jrcs/letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion)
+  - Provides a companion for the nginx-proxy its configuration and generating SSL certificates.
 - [haugene/docker-transmission-openvpn](https://github.com/haugene/docker-transmission-openvpn)
   - Provides Transmission, OpenVPN client, and the HTTP proxy that routes through the VPN.
 - [linuxserver/sonarr](https://hub.docker.com/r/linuxserver/sonarr)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,28 @@ services:
       - plex_net
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - nginx_conf:/etc/nginx/conf.d
+      - nginx_certs:/etc/nginx/certs:ro
+      - nginx_vhost:/etc/nginx/vhost.d
+      - nginx_html:/usr/share/nginx/html
+    labels:
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true"
+  
+  letsencrypt:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    container_name: letsencrypt
+    restart: ${RESTARTPOLICY}
+    depends_on:
+      - nginx
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - nginx_conf:/etc/nginx/conf.d
+      - nginx_certs:/etc/nginx/certs
+      - nginx_vhost:/etc/nginx/vhost.d
+      - nginx_html:/usr/share/nginx/html
 
   transmission:
     image: haugene/transmission-openvpn
@@ -52,6 +72,8 @@ services:
       - WEBPROXY_PORT=8888
       - VIRTUAL_HOST=transmission.${LOCALDOMAIN}
       - VIRTUAL_PORT=9091
+      - LETSENCRYPT_HOST=transmission.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
 
   proxy:
     image: haugene/transmission-openvpn-proxy
@@ -65,6 +87,8 @@ services:
       - TZ=${TZ}
       - VIRTUAL_HOST=proxy.${LOCALDOMAIN}
       - VIRTUAL_PORT=8080
+      - LETSENCRYPT_HOST=proxy.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     ports:
       - 8080:8080
 
@@ -82,6 +106,8 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
       - VIRTUAL_HOST=jackett.${LOCALDOMAIN}
+      - LETSENCRYPT_HOST=jackett.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/jackett/config:/config
@@ -107,6 +133,8 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
       - VIRTUAL_HOST=sonarr.${LOCALDOMAIN}
+      - LETSENCRYPT_HOST=sonarr.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/sonarr/config:/config
@@ -134,6 +162,8 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
       - VIRTUAL_HOST=radarr.${LOCALDOMAIN}
+      - LETSENCRYPT_HOST=radarr.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/radarr/config:/config
@@ -161,6 +191,8 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
       - VIRTUAL_HOST=ombi.${LOCALDOMAIN}
+      - LETSENCRYPT_HOST=ombi.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/ombi/config:/config
@@ -190,6 +222,8 @@ services:
       - PLEX_CLAIM=${PLEX_CLAIM}
       - VIRTUAL_HOST=plex.${LOCALDOMAIN}
       - VIRTUAL_PORT=32400
+      - LETSENCRYPT_HOST=plex.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     hostname: plex-docker
     volumes:
       # folder where config will be stored
@@ -213,6 +247,8 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
       - VIRTUAL_HOST=tautulli.${LOCALDOMAIN}
+      - LETSENCRYPT_HOST=tautulli.${LOCALDOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     ports:
       - 8181:8181
     volumes:
@@ -220,6 +256,12 @@ services:
       - ${DATAFOLDER}/tautulli/config:/config
       # Plex logs location
       - ${DATAFOLDER}/plex/config/Library/Application Support/Plex Media Server/Logs:/plex_logs:ro
+
+volumes:
+  nginx_conf:
+  nginx_certs:
+  nginx_vhost:
+  nginx_html:
 
 networks:
   torrent_net:


### PR DESCRIPTION
By adding the letsencrypt container, it will attach to the same files as the nginx-proxy container and it generates the nginx configurations to allow specific connections to each one of the containers accordingly.

The necessary SSL certificates will be generated by letsencrypt, validated and renewed by itself.

This resolves the #5.