### PR TITLE
Add Traefik with SSL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,20 @@
 version: '3'
 services:
-  nginx:
-    image: jwilder/nginx-proxy
-    container_name: nginx
+  traefik:
+    image: traefik
+    container_name: traefik
     restart: ${RESTARTPOLICY}
+    ports:
+      - 80:80
+      - 443:443
     networks:
+      - web
       - torrent_net
       - plex_net
-    ports:
-      - "80:80"
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DATAFOLDER}/traefik/traefik.toml:/traefik.toml
+      - ${DATAFOLDER}/traefik/acme.json:/acme.json
 
   transmission:
     image: haugene/transmission-openvpn
@@ -226,3 +230,5 @@ networks:
     driver: bridge
   plex_net:
     driver: bridge
+  web:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,21 +7,25 @@ services:
     ports:
       - 80:80
       - 443:443
+      - 8080:8080
     networks:
       - web
-      - torrent_net
-      - plex_net
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${DATAFOLDER}/traefik/traefik.toml:/traefik.toml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${DATAFOLDER}/traefik/traefik.toml:/traefik.toml:ro
       - ${DATAFOLDER}/traefik/acme.json:/acme.json
+    labels:
+      - traefik.enable=false
+      - traefik.frontend.rule=Host:traefik.${LOCALDOMAIN}
+      - traefik.port=8080
+      - traefik.frontend.entryPoints=http
 
   transmission:
     image: haugene/transmission-openvpn
     container_name: transmission
     restart: ${RESTARTPOLICY}
     depends_on:
-      - nginx
+      - traefik
     networks:
       - torrent_net
     cap_add:
@@ -54,8 +58,6 @@ services:
       - TZ=${TZ}
       - WEBPROXY_ENABLED=true
       - WEBPROXY_PORT=8888
-      - VIRTUAL_HOST=transmission.${LOCALDOMAIN}
-      - VIRTUAL_PORT=9091
 
   proxy:
     image: haugene/transmission-openvpn-proxy
@@ -63,29 +65,33 @@ services:
     restart: ${RESTARTPOLICY}
     networks:
       - torrent_net
+      - web
     depends_on:
       - transmission
     environment:
       - TZ=${TZ}
-      - VIRTUAL_HOST=proxy.${LOCALDOMAIN}
-      - VIRTUAL_PORT=8080
     ports:
-      - 8080:8080
+      - 8081:8080
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:transmission.${LOCALDOMAIN}
+      - traefik.port=8080
+      - traefik.frontend.entryPoints=http
 
   jackett:
     image: linuxserver/jackett
     container_name: jackett
     restart: ${RESTARTPOLICY}
     depends_on:
-      - nginx
+      - traefik
       - proxy
     networks:
       - torrent_net
+      - web
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - VIRTUAL_HOST=jackett.${LOCALDOMAIN}
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/jackett/config:/config
@@ -93,6 +99,11 @@ services:
       - ${MOUNTFOLDER}/jackett/blackhole:/downloads
     ports:
       - 9117:9117
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:jackett.${LOCALDOMAIN}
+      - traefik.port=9117
+      - traefik.frontend.entryPoints=http
 
   sonarr:
     image: linuxserver/sonarr
@@ -100,17 +111,22 @@ services:
     restart: ${RESTARTPOLICY}
     networks:
       - torrent_net
+      - web
     depends_on:
       - transmission
       - jackett
-      - nginx
+      - traefik
       - plex
       - proxy
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - VIRTUAL_HOST=sonarr.${LOCALDOMAIN}
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:sonarr.${LOCALDOMAIN}
+      - traefik.port=8989
+      - traefik.frontend.entryPoints=http
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/sonarr/config:/config
@@ -127,17 +143,22 @@ services:
     restart: ${RESTARTPOLICY}
     networks:
       - torrent_net
+      - web
     depends_on:
       - transmission
       - jackett
-      - nginx
+      - traefik
       - plex
       - proxy
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - VIRTUAL_HOST=radarr.${LOCALDOMAIN}
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:radarr.${LOCALDOMAIN}
+      - traefik.port=7878
+      - traefik.frontend.entryPoints=http
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/radarr/config:/config
@@ -156,15 +177,21 @@ services:
       - sonarr
       - radarr
       - plex
-      - nginx
+      - traefik
     networks:
       - plex_net
       - torrent_net
+      - web
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - VIRTUAL_HOST=ombi.${LOCALDOMAIN}
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:ombi.${LOCALDOMAIN}
+      - traefik.port=3579
+      - traefik.frontend.redirect.entryPoint=https
+      - traefik.frontend.headers.SSLRedirect=true
     volumes:
       # folder where config will be stored
       - ${DATAFOLDER}/ombi/config:/config
@@ -176,9 +203,10 @@ services:
     container_name: plex
     restart: ${RESTARTPOLICY}
     depends_on:
-      - nginx
+      - traefik
     networks:
       - plex_net
+      - web
     ports:
       - 32400:32400/tcp
       - 3005:3005/tcp
@@ -192,8 +220,6 @@ services:
     environment:
       - TZ=${TZ}
       - PLEX_CLAIM=${PLEX_CLAIM}
-      - VIRTUAL_HOST=plex.${LOCALDOMAIN}
-      - VIRTUAL_PORT=32400
     hostname: plex-docker
     volumes:
       # folder where config will be stored
@@ -202,6 +228,11 @@ services:
       - ${DATAFOLDER}/plex/temp:/transcode
       # media folder where all movies and series are stored
       - ${MOUNTFOLDER}/MEDIA:/data
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:plex.${LOCALDOMAIN}
+      - traefik.port=32400
+      - traefik.frontend.entryPoints=http
 
   tautulli:
     image: tautulli/tautulli
@@ -209,14 +240,19 @@ services:
     restart: ${RESTARTPOLICY}
     depends_on:
       - plex
-      - nginx
+      - traefik
     networks:
       - plex_net
+      - web
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - VIRTUAL_HOST=tautulli.${LOCALDOMAIN}
+    labels:
+      - traefik.enable=true
+      - traefik.frontend.rule=Host:tautulli.${LOCALDOMAIN}
+      - traefik.port=8181
+      - traefik.frontend.entryPoints=http
     ports:
       - 8181:8181
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -231,4 +231,4 @@ networks:
   plex_net:
     driver: bridge
   web:
-    external: true
+    driver: bridge

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,0 +1,29 @@
+debug = false
+
+logLevel = "ERROR"
+defaultEntryPoints = ["https","http"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+  [entryPoints.https.tls]
+
+[retry]
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+domain = "my-awesome-app.org"
+watch = true
+exposedByDefault = false
+
+[acme]
+email = "your-email-here@my-awesome-app.org"
+storage = "acme.json"
+entryPoint = "https"
+onHostRule = true
+[acme.httpChallenge]
+entryPoint = "http"

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,9 +1,12 @@
 debug = false
 
 logLevel = "ERROR"
+
 defaultEntryPoints = ["https","http"]
 
 [entryPoints]
+  [entryPoints.dashboard]
+    address = ":8080"
   [entryPoints.http]
   address = ":80"
     [entryPoints.http.redirect]
@@ -12,18 +15,22 @@ defaultEntryPoints = ["https","http"]
   address = ":443"
   [entryPoints.https.tls]
 
+[api]
+entrypoint="dashboard"
+
 [retry]
 
-[docker]
-endpoint = "unix:///var/run/docker.sock"
-domain = "my-awesome-app.org"
-watch = true
-exposedByDefault = false
-
 [acme]
-email = "your-email-here@my-awesome-app.org"
+email = "your-email-here"
 storage = "acme.json"
 entryPoint = "https"
 onHostRule = true
-[acme.httpChallenge]
-entryPoint = "http"
+  [acme.httpChallenge]
+    entryPoint = "http"
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+domain = "your-domain-here"
+watch = true
+exposedByDefault = false
+network = "web"

--- a/traefik.toml
+++ b/traefik.toml
@@ -8,12 +8,10 @@ defaultEntryPoints = ["https","http"]
   [entryPoints.dashboard]
     address = ":8080"
   [entryPoints.http]
-  address = ":80"
-    [entryPoints.http.redirect]
-    entryPoint = "https"
+    address = ":80"
   [entryPoints.https]
-  address = ":443"
-  [entryPoints.https.tls]
+    address = ":443"
+    [entryPoints.https.tls]
 
 [api]
 entrypoint="dashboard"

--- a/traefik.toml
+++ b/traefik.toml
@@ -33,4 +33,4 @@ endpoint = "unix:///var/run/docker.sock"
 domain = "your-domain-here"
 watch = true
 exposedByDefault = false
-network = "web"
+network = "hms-docker_web"


### PR DESCRIPTION
Resolves #5 and replaces ```jwilder/nginx-proxy``` with ```traefik```. Will only request a cert for ```ombi.${LOCALDOMAIN}``` and you must have this as a DNS entry with your registrar. Without the DNS entry, the IP cannot resolve and will count as a failed authorization for Let's Encrypt. This is also why the other containers are disabled for HTTPS as I believe they should only be accessed by LAN anyways. 

In order to add other containers to have SSL, you must put the labels ```traefik.frontend.redirect.entryPoint=https``` and ```traefik.frontend.headers.SSLRedirect=true``` in the docker-compose file under the correct container.